### PR TITLE
Fix AppVeyor build - upgrade Node.js 14 to 20

### DIFF
--- a/appveyor.yml
+++ b/appveyor.yml
@@ -1,6 +1,6 @@
 image: Ubuntu
 
-stack: node 14
+stack: node 20
 
 branches:
   only:


### PR DESCRIPTION
## Problem
AppVeyor builds are failing because Node.js 14 reached End-of-Life in April 2023.

## Solution
Upgrade to Node.js 20 (current LTS).

## Changes
-  → 

This should fix any "npm install" failures caused by packages dropping Node 14 support.